### PR TITLE
Phase 9: Complete core functionality

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -217,9 +217,10 @@ int service_run_host(rootstream_ctx_t *ctx) {
 
         /* Encode frame */
         size_t enc_size = 0;
+        bool is_keyframe = false;
         uint64_t encode_start_us = get_timestamp_us();
-        if (rootstream_encode_frame(ctx, &ctx->current_frame,
-                                   enc_buf, &enc_size) < 0) {
+        if (rootstream_encode_frame_ex(ctx, &ctx->current_frame,
+                                      enc_buf, &enc_size, &is_keyframe) < 0) {
             fprintf(stderr, "ERROR: Encode failed (frame=%lu)\n", ctx->frames_captured);
             continue;
         }
@@ -227,8 +228,7 @@ int service_run_host(rootstream_ctx_t *ctx) {
 
         /* Write to recording file if active */
         if (ctx->recording.active) {
-            /* TODO: Detect actual keyframes from encoder */
-            bool is_keyframe = (ctx->frames_encoded % ctx->display.refresh_rate) == 0;
+            /* Use real keyframe detection from encoder */
             if (recording_write_frame(ctx, enc_buf, enc_size, is_keyframe) < 0) {
                 fprintf(stderr, "WARNING: Failed to write frame to recording\n");
             }


### PR DESCRIPTION
## Summary

- **PKT_CONTROL packet handling**: Implement control message protocol with pause/resume, bitrate/FPS/quality adjustment, keyframe requests, and graceful disconnect
- **Hostname resolution**: Replace hardcoded localhost with proper DNS resolution via `getaddrinfo()` and mDNS support for `.local` domains
- **Real keyframe detection**: Parse H.264/H.265 NAL units to detect actual IDR frames instead of using frame counter heuristics
- **Force keyframe**: Add `force_keyframe` flag to encoder context for on-demand IDR generation

## Changes

| File | Description |
|------|-------------|
| `include/rootstream.h` | Add `control_cmd_t` enum, `control_packet_t` struct, `is_keyframe` to frame buffer, `force_keyframe` to encoder, new API functions |
| `src/network.c` | Implement PKT_CONTROL handling, hostname resolution, control command send helpers |
| `src/vaapi_encoder.c` | Add NAL parsing for keyframe detection, force_keyframe support, `rootstream_encode_frame_ex()` |
| `src/nvenc_encoder.c` | Add NAL parsing for keyframe detection, force_keyframe support |
| `src/service.c` | Use real keyframe detection for recording |

## Test plan

- [ ] Test PKT_CONTROL commands (pause/resume stream)
- [ ] Test hostname resolution with IP address, DNS hostname, and .local mDNS
- [ ] Verify keyframe detection in recording files with `rstr-info`
- [ ] Test force keyframe via CTRL_REQUEST_KEYFRAME

🤖 Generated with [Claude Code](https://claude.com/claude-code)