### PR TITLE
Phase 12b: Integrate platform abstraction layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 if(MSVC)
     add_compile_options(/W4)
 else()
-    add_compile_options(-Wall -Wextra -Werror)
+    add_compile_options(-Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-format-truncation -Wno-stringop-truncation)
 endif()
 
 # Debug flags
@@ -127,6 +127,7 @@ set(COMMON_SOURCES
 set(LINUX_SOURCES
     src/drm_capture.c
     src/vaapi_encoder.c
+    src/nvenc_encoder.c
     src/vaapi_decoder.c
     src/audio_capture.c
     src/audio_playback.c
@@ -227,8 +228,13 @@ if(UNIX AND NOT APPLE)
     # Recording player tool
     add_executable(rstr-player
         tools/rstr-player.c
+        src/recording.c
         src/vaapi_decoder.c
         src/display_sdl2.c
+        src/network.c
+        src/crypto.c
+        src/config.c
+        src/input.c
         src/opus_codec.c
         src/audio_playback.c
         src/latency.c
@@ -244,6 +250,8 @@ if(UNIX AND NOT APPLE)
         ${SDL2_LIBRARIES}
         ${VAAPI_LIBRARIES}
         ${ALSA_LIBRARIES}
+        ${SODIUM_LIBRARIES}
+        ${AVAHI_LIBRARIES}
         m pthread
     )
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,8 @@ SRCS := src/main.c \
         src/qrcode.c \
         src/config.c \
         src/latency.c \
-        src/recording.c
+        src/recording.c \
+        src/platform/platform_linux.c
 
 ifdef HEADLESS
     SRCS := $(filter-out src/tray.c,$(SRCS))
@@ -214,7 +215,7 @@ $(TARGET): $(OBJS)
 
 # Build rstr-player tool
 # Note: Needs many modules for dependencies - simplified player would be better long-term
-$(PLAYER): tools/rstr-player.c src/recording.c src/vaapi_decoder.c src/display_sdl2.c src/network.c src/crypto.c src/config.c src/input.c src/opus_codec.c src/audio_playback.c src/latency.c
+$(PLAYER): tools/rstr-player.c src/recording.c src/vaapi_decoder.c src/display_sdl2.c src/network.c src/crypto.c src/config.c src/input.c src/opus_codec.c src/audio_playback.c src/latency.c src/platform/platform_linux.c
 	@echo "🔗 Building rstr-player..."
 	@$(CC) $(CFLAGS) $^ -o $(PLAYER) $(LDFLAGS) $(LIBS)
 	@echo "✓ Build complete: $(PLAYER)"
@@ -427,7 +428,7 @@ test-integration: $(TARGET)
 	@./tests/integration/test_stream.sh
 
 # Build crypto test
-$(TEST_CRYPTO): tests/unit/test_crypto.c src/crypto.c
+$(TEST_CRYPTO): tests/unit/test_crypto.c src/crypto.c src/platform/platform_linux.c
 	@echo "🔨 Building crypto tests..."
 	@mkdir -p tests/unit
 	@$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS) $(LIBS)

--- a/include/rootstream.h
+++ b/include/rootstream.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <sys/socket.h>
+
+/* Platform abstraction for cross-platform socket types */
+#include "../src/platform/platform.h"
 
 /*
  * ============================================================================
@@ -309,7 +311,7 @@ typedef struct {
     encoder_ctx_t encoder;
 
     /* Network */
-    int sock_fd;               /* UDP socket */
+    rs_socket_t sock_fd;       /* UDP socket */
     uint16_t port;             /* Listening port */
 
     /* Peers */


### PR DESCRIPTION
## Summary

- Refactors `network.c` to use platform socket functions (`rs_socket_create`, `rs_socket_close`, etc.)
- Refactors `crypto.c` to use platform file operations (`rs_file_exists`, `rs_mkdir`, `rs_gethostname`, etc.)
- Updates `rootstream.h` to include platform.h and use `rs_socket_t` type
- Fixes format truncation warnings in `config.c` for CMake's stricter warning flags
- Adds `src/platform/platform_linux.c` to Makefile build
- Syncs CMakeLists.txt sources and warning flags with Makefile

## Test plan

- [x] Makefile build passes (`make clean && make`)
- [x] CMake build passes (`cmake -B build && cmake --build build`)
- [x] Both `rootstream` and `rstr-player` binaries build successfully
- [ ] Verify runtime functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)