### PR TITLE
Add video chunking for client decode

### DIFF
--- a/src/decoder_mf.c
+++ b/src/decoder_mf.c
@@ -461,6 +461,7 @@ int rootstream_decode_frame(rootstream_ctx_t *ctx,
                 /* Fill output frame info */
                 out->data = mf->frame_buffer;
                 out->size = (uint32_t)copy_size;
+                out->capacity = (uint32_t)mf->frame_buffer_size;
                 out->width = mf->width;
                 out->height = mf->height;
                 out->pitch = mf->width;  /* NV12 Y-plane pitch */

--- a/src/drm_capture.c
+++ b/src/drm_capture.c
@@ -240,6 +240,7 @@ int rootstream_capture_init(rootstream_ctx_t *ctx) {
     ctx->current_frame.width = ctx->display.width;
     ctx->current_frame.height = ctx->display.height;
     ctx->current_frame.size = frame_size;
+    ctx->current_frame.capacity = frame_size;
     ctx->current_frame.format = 0x34325258; /* DRM_FORMAT_XRGB8888 */
 
     printf("✓ DRM capture initialized: %dx%d @ %d Hz\n",

--- a/src/service.c
+++ b/src/service.c
@@ -269,8 +269,8 @@ int service_run_host(rootstream_ctx_t *ctx) {
             peer_t *peer = &ctx->peers[i];
             if (peer->state == PEER_CONNECTED && peer->is_streaming) {
                 /* Send video */
-                if (rootstream_net_send_encrypted(ctx, peer, PKT_VIDEO,
-                                                  enc_buf, enc_size) < 0) {
+                if (enc_size > 0 &&
+                    rootstream_net_send_video(ctx, peer, enc_buf, enc_size) < 0) {
                     fprintf(stderr, "ERROR: Video send failed (peer=%s)\n", peer->hostname);
                 }
 
@@ -370,8 +370,6 @@ int service_run_client(rootstream_ctx_t *ctx) {
 
         /* Check if we received a video frame */
         if (ctx->current_frame.data && ctx->current_frame.size > 0) {
-            ctx->frames_received++;
-
             /* Decode frame */
             uint64_t decode_start_us = get_timestamp_us();
             if (rootstream_decode_frame(ctx, ctx->current_frame.data,

--- a/src/vaapi_decoder.c
+++ b/src/vaapi_decoder.c
@@ -320,15 +320,17 @@ int rootstream_decode_frame(rootstream_ctx_t *ctx,
     out->timestamp = get_timestamp_us();
 
     /* Allocate output buffer if needed */
-    if (!out->data) {
-        out->data = malloc(out->size);
-        if (!out->data) {
+    if (!out->data || out->capacity < out->size) {
+        uint8_t *new_buf = realloc(out->data, out->size);
+        if (!new_buf) {
             fprintf(stderr, "ERROR: Cannot allocate output buffer\n");
             vaUnmapBuffer(dec->display, image.buf);
             vaDestroyImage(dec->display, image.image_id);
             vaDestroyBuffer(dec->display, slice_data_buf);
             return -1;
         }
+        out->data = new_buf;
+        out->capacity = out->size;
     }
 
     /* Copy pixel data */


### PR DESCRIPTION
## Summary
- fragment encoded video frames into UDP-sized chunks
- reassemble chunks on client before decode
- track frame buffer capacity to avoid invalid size checks

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build