### PR TITLE
Harden handshake and keepalive flow

### DIFF
--- a/include/rootstream.h
+++ b/include/rootstream.h
@@ -267,6 +267,8 @@ typedef struct {
     size_t video_rx_capacity;                        /* Reassembly buffer size */
     size_t video_rx_expected;                        /* Expected frame size */
     size_t video_rx_received;                        /* Bytes received so far */
+    uint64_t last_sent;                              /* Last outbound packet time (ms) */
+    uint64_t last_ping;                              /* Last keepalive ping time (ms) */
 } peer_t;
 
 /* ============================================================================
@@ -391,6 +393,7 @@ typedef struct {
     uint64_t bytes_sent;
     uint64_t bytes_received;
     latency_stats_t latency;   /* Latency instrumentation */
+    bool is_host;              /* Host mode (streamer) */
 } rootstream_ctx_t;
 
 /* ============================================================================
@@ -493,6 +496,7 @@ int rootstream_net_send_video(rootstream_ctx_t *ctx, peer_t *peer,
                               const uint8_t *data, size_t size);
 int rootstream_net_recv(rootstream_ctx_t *ctx, int timeout_ms);
 int rootstream_net_handshake(rootstream_ctx_t *ctx, peer_t *peer);
+void rootstream_net_tick(rootstream_ctx_t *ctx);
 
 /* --- Peer Management --- */
 peer_t* rootstream_add_peer(rootstream_ctx_t *ctx, const char *rootstream_code);

--- a/src/main.c
+++ b/src/main.c
@@ -144,6 +144,7 @@ static int run_host_mode(rootstream_ctx_t *ctx, int display_idx, bool no_discove
     printf("INFO: Starting host mode\n");
     printf("INFO: Press Ctrl+C to stop\n");
     printf("\n");
+    ctx->is_host = true;
 
     /* Detect and select display */
     display_info_t displays[MAX_DISPLAYS];
@@ -373,6 +374,7 @@ int main(int argc, char **argv) {
 
     ctx.port = port;
     ctx.encoder.bitrate = (uint32_t)bitrate * 1000;
+    ctx.is_host = false;
 
     /* Handle --list-displays flag */
     if (list_displays) {

--- a/src/service.c
+++ b/src/service.c
@@ -297,6 +297,7 @@ int service_run_host(rootstream_ctx_t *ctx) {
 
         /* Process incoming packets */
         rootstream_net_recv(ctx, 1);
+        rootstream_net_tick(ctx);
 
         /* Rate limiting */
         uint32_t refresh_rate = ctx->display.refresh_rate ? ctx->display.refresh_rate : 60;
@@ -367,6 +368,7 @@ int service_run_client(rootstream_ctx_t *ctx) {
         uint64_t recv_start_us = get_timestamp_us();
         rootstream_net_recv(ctx, 16);
         uint64_t recv_end_us = get_timestamp_us();
+        rootstream_net_tick(ctx);
 
         /* Check if we received a video frame */
         if (ctx->current_frame.data && ctx->current_frame.size > 0) {


### PR DESCRIPTION
## Summary
- add peer lookup by address and peer housekeeping tick
- retry handshakes and send keepalive pings
- auto-start streaming on host after handshake and request keyframes on client

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build