### PR TITLE
Add A/V timestamps and basic sync

### DIFF
--- a/include/rootstream.h
+++ b/include/rootstream.h
@@ -226,7 +226,17 @@ typedef PACKED_STRUCT {
     uint32_t offset;       /* Offset of this chunk */
     uint16_t chunk_size;   /* Size of this chunk */
     uint16_t flags;        /* Reserved for future use */
+    uint64_t timestamp_us; /* Capture timestamp */
 } video_chunk_header_t;
+PACKED_STRUCT_END
+
+/* Audio payload header (inside encrypted payload) */
+typedef PACKED_STRUCT {
+    uint64_t timestamp_us; /* Capture timestamp */
+    uint32_t sample_rate;  /* Samples per second */
+    uint16_t channels;     /* Channel count */
+    uint16_t samples;      /* Samples per channel */
+} audio_packet_header_t;
 PACKED_STRUCT_END
 
 /* Encrypted input event payload */
@@ -394,6 +404,8 @@ typedef struct {
     uint64_t bytes_received;
     latency_stats_t latency;   /* Latency instrumentation */
     bool is_host;              /* Host mode (streamer) */
+    uint64_t last_video_ts_us; /* Last received video timestamp */
+    uint64_t last_audio_ts_us; /* Last received audio timestamp */
 } rootstream_ctx_t;
 
 /* ============================================================================
@@ -493,7 +505,8 @@ int rootstream_net_init(rootstream_ctx_t *ctx, uint16_t port);
 int rootstream_net_send_encrypted(rootstream_ctx_t *ctx, peer_t *peer,
                                   uint8_t type, const void *data, size_t size);
 int rootstream_net_send_video(rootstream_ctx_t *ctx, peer_t *peer,
-                              const uint8_t *data, size_t size);
+                              const uint8_t *data, size_t size,
+                              uint64_t timestamp_us);
 int rootstream_net_recv(rootstream_ctx_t *ctx, int timeout_ms);
 int rootstream_net_handshake(rootstream_ctx_t *ctx, peer_t *peer);
 void rootstream_net_tick(rootstream_ctx_t *ctx);

--- a/src/network_stub.c
+++ b/src/network_stub.c
@@ -28,6 +28,18 @@ int rootstream_net_send_encrypted(rootstream_ctx_t *ctx, peer_t *peer,
     return -1;
 }
 
+int rootstream_net_send_video(rootstream_ctx_t *ctx, peer_t *peer,
+                              const uint8_t *data, size_t size,
+                              uint64_t timestamp_us) {
+    (void)ctx;
+    (void)peer;
+    (void)data;
+    (void)size;
+    (void)timestamp_us;
+    fprintf(stderr, "ERROR: Cannot send video (NO_CRYPTO build)\n");
+    return -1;
+}
+
 int rootstream_net_recv(rootstream_ctx_t *ctx, int timeout_ms) {
     (void)ctx;
     (void)timeout_ms;
@@ -40,6 +52,10 @@ int rootstream_net_handshake(rootstream_ctx_t *ctx, peer_t *peer) {
     (void)peer;
     fprintf(stderr, "ERROR: Cannot handshake (NO_CRYPTO build)\n");
     return -1;
+}
+
+void rootstream_net_tick(rootstream_ctx_t *ctx) {
+    (void)ctx;
 }
 
 peer_t* rootstream_add_peer(rootstream_ctx_t *ctx, const char *rootstream_code) {

--- a/src/nvenc_encoder.c
+++ b/src/nvenc_encoder.c
@@ -293,8 +293,11 @@ int rootstream_encoder_init_nvenc(rootstream_ctx_t *ctx, codec_type_t codec) {
     /* Set encoding parameters */
     nv->width = ctx->display.width;
     nv->height = ctx->display.height;
-    nv->fps = ctx->display.refresh_rate;
-    nv->bitrate = ctx->settings.video_bitrate;
+    nv->fps = ctx->display.refresh_rate ? ctx->display.refresh_rate : 60;
+    nv->bitrate = ctx->encoder.bitrate;
+    if (nv->bitrate == 0) {
+        nv->bitrate = ctx->settings.video_bitrate;
+    }
     if (nv->bitrate == 0) {
         nv->bitrate = 10000000;  /* 10 Mbps default */
     }


### PR DESCRIPTION
## Summary
- add timestamped video chunks and audio packet headers
- perform basic audio/video sync on client
- prefer CLI bitrate and guard missing refresh rate in NVENC

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build