### PR TITLE
Polish audio settings and NVENC selection

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -559,6 +559,9 @@ int rootstream_net_recv(rootstream_ctx_t *ctx, int timeout_ms) {
                 }
             }
             else if (hdr->type == PKT_AUDIO) {
+                if (!ctx->settings.audio_enabled) {
+                    break;
+                }
                 /* Decode Opus audio and play immediately */
                 if (decrypted_len < sizeof(audio_packet_header_t)) {
                     fprintf(stderr, "WARNING: Audio packet too small: %zu bytes\n", decrypted_len);

--- a/src/opus_codec.c
+++ b/src/opus_codec.c
@@ -60,7 +60,10 @@ int rootstream_opus_encoder_init(rootstream_ctx_t *ctx) {
     opus->sample_rate = OPUS_SAMPLE_RATE;
     opus->channels = OPUS_CHANNELS;
     opus->frame_size = OPUS_FRAME_SIZE;
-    opus->bitrate = OPUS_BITRATE;
+    opus->bitrate = ctx->settings.audio_bitrate;
+    if (opus->bitrate == 0) {
+        opus->bitrate = OPUS_BITRATE;
+    }
 
     /* Create Opus encoder */
     int error;
@@ -116,7 +119,10 @@ int rootstream_opus_decoder_init(rootstream_ctx_t *ctx) {
         opus->sample_rate = OPUS_SAMPLE_RATE;
         opus->channels = OPUS_CHANNELS;
         opus->frame_size = OPUS_FRAME_SIZE;
+    opus->bitrate = ctx->settings.audio_bitrate;
+    if (opus->bitrate == 0) {
         opus->bitrate = OPUS_BITRATE;
+    }
         ctx->uinput_kbd_fd = (int)(intptr_t)opus;
     }
 

--- a/src/service.c
+++ b/src/service.c
@@ -355,11 +355,15 @@ int service_run_client(rootstream_ctx_t *ctx) {
     }
 
     /* Initialize audio playback and Opus decoder */
-    if (audio_playback_init(ctx) < 0) {
-        fprintf(stderr, "WARNING: Audio playback init failed (continuing without audio)\n");
-    } else if (rootstream_opus_decoder_init(ctx) < 0) {
-        fprintf(stderr, "WARNING: Opus decoder init failed (continuing without audio)\n");
-        audio_playback_cleanup(ctx);
+    if (ctx->settings.audio_enabled) {
+        if (audio_playback_init(ctx) < 0) {
+            fprintf(stderr, "WARNING: Audio playback init failed (continuing without audio)\n");
+        } else if (rootstream_opus_decoder_init(ctx) < 0) {
+            fprintf(stderr, "WARNING: Opus decoder init failed (continuing without audio)\n");
+            audio_playback_cleanup(ctx);
+        }
+    } else {
+        printf("INFO: Audio disabled in settings\n");
     }
 
     printf("✓ Client initialized - ready to receive video and audio\n");
@@ -425,8 +429,10 @@ int service_run_client(rootstream_ctx_t *ctx) {
         free(decoded_frame.data);
     }
 
-    audio_playback_cleanup(ctx);
-    rootstream_opus_cleanup(ctx);
+    if (ctx->settings.audio_enabled) {
+        audio_playback_cleanup(ctx);
+        rootstream_opus_cleanup(ctx);
+    }
     display_cleanup(ctx);
     rootstream_decoder_cleanup(ctx);
 


### PR DESCRIPTION
## Summary
- honor audio enablement/bitrate settings for Opus
- skip client audio init when audio is disabled
- auto-select NVENC in host mode with VA-API fallback

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build