### PR TITLE
Add display selection to settings

### DIFF
--- a/include/rootstream.h
+++ b/include/rootstream.h
@@ -322,6 +322,7 @@ typedef struct {
     uint32_t video_bitrate;    /* Target bitrate (bits/sec) */
     uint32_t video_framerate;  /* Target framerate (fps) */
     char video_codec[16];      /* Codec: "h264", "h265" */
+    int display_index;         /* Preferred display index */
 
     /* Audio settings */
     bool audio_enabled;        /* Enable audio streaming */

--- a/src/main.c
+++ b/src/main.c
@@ -308,7 +308,7 @@ int main(int argc, char **argv) {
     bool service_mode = false;
     bool no_discovery = false;
     uint16_t port = 9876;
-    int display_idx = 0;
+    int display_idx = -1;
     int bitrate = 10000;
     const char *record_file = NULL;
     bool latency_log = false;
@@ -389,6 +389,10 @@ int main(int argc, char **argv) {
     ctx.port = port;
     ctx.encoder.bitrate = (uint32_t)bitrate * 1000;
     ctx.is_host = false;
+
+    if (display_idx < 0) {
+        display_idx = ctx.settings.display_index;
+    }
 
     /* Handle --list-displays flag */
     if (list_displays) {


### PR DESCRIPTION
## Summary
- persist preferred display index in config
- expose display selection in tray settings
- default host display to saved setting when CLI omits --display

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build