### PR TITLE
Add protocol version negotiation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -45,12 +45,14 @@ PKT_PONG      = 0x07
 
 ## Handshake
 
-Handshake is unencrypted and establishes a shared session key.
+Handshake is unencrypted and establishes a shared session key. It also carries optional protocol metadata.
 
 Payload format:
 ```
 [32 bytes] Ed25519 public key
 [N bytes]  hostname (null‑terminated)
+[1 byte]   protocol version (optional)
+[1 byte]   protocol flags (optional)
 ```
 
 Flow:
@@ -59,6 +61,8 @@ Flow:
 3. Server responds with its own PKT_HANDSHAKE.
 4. Client derives the same shared secret.
 5. Both sides set `session.authenticated = true` and start encrypted traffic.
+
+If version/flags are missing, peers assume protocol version 1 and flags 0.
 
 ## Encryption
 
@@ -144,7 +148,7 @@ CTRL_DISCONNECT       0x07
 ## Versioning
 
 Protocol version is in the header. Compatibility rules:
-- Major version must match.
+- Accept versions in `[PROTOCOL_MIN_VERSION, PROTOCOL_VERSION]`.
 - New fields should be appended to payloads with safe defaults.
 - Unknown packet types should be ignored.
 

--- a/include/rootstream.h
+++ b/include/rootstream.h
@@ -47,6 +47,9 @@
  */
 
 #define ROOTSTREAM_VERSION "1.0.0"
+#define PROTOCOL_VERSION 1
+#define PROTOCOL_MIN_VERSION 1
+#define PROTOCOL_FLAGS 0
 #define MAX_DISPLAYS 4
 #define MAX_PACKET_SIZE 1400
 #define MAX_PEERS 16
@@ -279,6 +282,8 @@ typedef struct {
     size_t video_rx_received;                        /* Bytes received so far */
     uint64_t last_sent;                              /* Last outbound packet time (ms) */
     uint64_t last_ping;                              /* Last keepalive ping time (ms) */
+    uint8_t protocol_version;                       /* Peer protocol version */
+    uint8_t protocol_flags;                         /* Peer protocol flags */
 } peer_t;
 
 /* ============================================================================

--- a/src/packet_validate.c
+++ b/src/packet_validate.c
@@ -14,7 +14,7 @@ int rootstream_net_validate_packet(const uint8_t *buffer, size_t len) {
         return -1;
     }
 
-    if (hdr->version != 1) {
+    if (hdr->version < PROTOCOL_MIN_VERSION || hdr->version > PROTOCOL_VERSION) {
         return -1;
     }
 


### PR DESCRIPTION
## Summary
- include protocol version/flags in handshake payload
- enforce supported protocol version ranges
- document negotiation in PROTOCOL.md

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build